### PR TITLE
examples: read only `num_packets` from the device

### DIFF
--- a/examples/pcap_example.rs
+++ b/examples/pcap_example.rs
@@ -32,7 +32,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         _ => todo!(),
     };
 
+    let mut counter = 0;
     while let Ok(packet) = cap.next_packet() {
+        if let Some(num_packets) = opts.num_packets {
+            if counter >= num_packets {
+                break;
+            }
+        }
+        counter += 1;
+
         eprintln!("packet.data: {}", hex::encode(packet.data));
         let p = scalpel::Packet::from_bytes(&packet.data, encap_type);
         match p {

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -170,7 +170,7 @@ impl Packet {
             let _ = core::mem::replace(&mut p.unprocessed, bytes[start..].to_vec());
         }
 
-        #[cfg(features = "logging")]
+        #[cfg(feature = "logging")]
         log::debug!("Decoded packet: {:#?}", p);
 
         Ok(p)


### PR DESCRIPTION
- We stop the example if `num_packets` packets are read.
- Change cfg attribute from features(..) to feature(..)