### PR TITLE
Removed `lazy_static` dependency.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,6 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 hex = {version = "0.4", features = ["serde"]}
-lazy_static = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
 erased-serde = "0.4"

--- a/src/layers/linux_sll.rs
+++ b/src/layers/linux_sll.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 use crate::errors::Error;
 use crate::{Layer, Packet, ENCAP_TYPE_LINUX_SLL};
 
-use crate::layers::ethernet::ETHERTYPES_MAP;
+use crate::layers::ethernet::get_ethertypes_map;
 
 #[derive(Debug, Default, Serialize)]
 pub struct LinuxSll {
@@ -49,7 +49,7 @@ impl Layer for LinuxSll {
         self.ll_addr = bytes[6..14].try_into().unwrap();
         self.protocol = u16::from_be_bytes(bytes[14..16].try_into().unwrap());
 
-        let map = ETHERTYPES_MAP.read().unwrap();
+        let map = get_ethertypes_map().read().unwrap();
         let layer = map.get(&self.protocol);
         match layer {
             None => Ok((None, LINUX_SLL_HEADER_LENGTH)),

--- a/src/layers/linux_sll2.rs
+++ b/src/layers/linux_sll2.rs
@@ -7,7 +7,7 @@ use serde::Serialize;
 use crate::errors::Error;
 use crate::{Layer, Packet, ENCAP_TYPE_LINUX_SLL2};
 
-use crate::layers::ethernet::ETHERTYPES_MAP;
+use crate::layers::ethernet::get_ethertypes_map;
 
 #[derive(Debug, Default, Serialize)]
 pub struct LinuxSll2 {
@@ -53,7 +53,7 @@ impl Layer for LinuxSll2 {
         self.ll_addr_len = bytes[11];
         self.ll_addr = bytes[12..20].try_into().unwrap();
 
-        let map = ETHERTYPES_MAP.read().unwrap();
+        let map = get_ethertypes_map().read().unwrap();
         let layer = map.get(&self.proto_type);
         match layer {
             None => Ok((None, LINUX_SLL2_HEADER_LENGTH)),


### PR DESCRIPTION
Using `OnceLock` in place of `lazy_static` to initialize the required global maps.