### PR TITLE
Adding WASM support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ serde_json = { version = "1.0" }
 erased-serde = "0.4"
 pyo3 = { version = "0.20", features = ["extension-module"], optional=true}
 log =  { version = "0.4", optional = true }
+wasm-bindgen = "0.2.92"
 
 [dev-dependencies]
 criterion = "0.5"

--- a/index.html
+++ b/index.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en-US">
+<head>
+  <meta charset="utf-8" />
+  <title>Scalpel using WASM</title>
+</head>
+<body>
+
+<h1>Scalpel using WASM</h1>
+<h2>Byte Stream to be dissected</h2>
+<p id="byteStream"></p>
+
+<button id="dissectButton">Dissect Packet</button>
+<div id="output"></div>
+
+<script type="module">
+  import init, { dissect_packet } from "./pkg/scalpel.js";
+
+  const byteStream = "003096e6fc3900309605283888470001ddff45c0002800030000ff06a4e80a0102010a2200012af90017983210058dd58ea55010102099cd00000000";
+
+  async function initialize() {
+    await init();
+    showByteStream();
+    document.getElementById('dissectButton').addEventListener('click', handleDissectClick);
+  }
+
+  function handleDissectClick() {
+    const result = dissect_packet(byteStream);
+    document.getElementById('output').innerText = result;
+  }
+
+  function showByteStream() {
+    document.getElementById('byteStream').innerText = byteStream;
+  }
+
+  window.onload = initialize;
+</script>
+
+</body>
+</html>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,23 @@ pub use types::{ENCAP_TYPE_ETH, ENCAP_TYPE_LINUX_SLL, ENCAP_TYPE_LINUX_SLL2};
 #[cfg(feature = "python-bindings")]
 use pyo3::prelude::*;
 
+use wasm_bindgen::prelude::*;
+
+#[wasm_bindgen]
+pub fn dissect_packet(packet: String) -> String {
+    let _ = layers::register_defaults();
+
+    let packet = hex::decode(packet);
+    
+    let packet = packet.unwrap();
+
+    let p = Packet::from_bytes(&packet, ENCAP_TYPE_ETH);
+    
+    let p = p.unwrap();
+
+    serde_json::to_string_pretty(&p).unwrap()
+}
+
 /// Python bindings for packet dissection and sculpting in Rust (scalpel)
 #[cfg(feature = "python-bindings")]
 #[pymodule]


### PR DESCRIPTION
Referencing #61 

We had discussed about whether our crate can support WASM. This PR creates a demonstration of the same.

# Instructions to run
1. Firstly, you need to have `wasm-pack` installed. It can be found [here](https://rustwasm.github.io/wasm-pack/installer/). Simply run `cargo install wasm-pack`. This is used to create the WASM files based on our target (which in this case is the web). It also has the potential to create WASM files for different targets as well such as NodeJS.
2. Next, you must create the WASM file. This can be done by running `wasm-pack build --target web`. It will create WASM binaries in `./pkg/`. 
3. Finally, we must have `index.html` served by a simple Python server to avoid CORS issues. This can be done by running `python -m http.server` in the same directory as `index.html`.
4. Go to the URL given by the Python server as you should see a simple HTML page like this:
![image](https://github.com/ystero-dev/scalpel/assets/42250012/bd96bf6b-1473-413d-95c1-2256bbdcb463)
5. Click the `Dissect Packet` button to see this:
![image](https://github.com/ystero-dev/scalpel/assets/42250012/9d43ba9e-7b19-4965-b0a9-38b2ccd33a82)

# My Analysis
- For this demonstration, I had to use the `./pkg/scalpel.js`, created by `wasm-pack`. I tried loading the `./pkg/scalpel_bg.wasm` file directly into the script, however, I was facing some import issues. It turns out that ```WebAssembly is not yet integrated with <script type='module'> or import statements, thus there is not a path to have the browser fetch modules for you using imports.``` as stated in [MDN Docs](https://developer.mozilla.org/en-US/docs/WebAssembly/Loading_and_running). Therefore, instead of tediously creating the `ArrayBuffer`s for containing the WASM binary and following a few more steps, I ended up using the `wasm-pack` generated `./pkg/scalpel.js` file. *(However, the alternative options of loading and running the WASM binary directly can be explored)*
- I have added a `dissect_packet` function to the `lib.rs` file **temporarily**. `wasm-pack` generates WASM bindings for particular functions, that have the `#[wasm_bindgen]` attribute. They can't be tested from examples. Therefore, we need to look into creating a separate module to provide the functions that can be used by the browser, or any other entity using the WASM file.  *The functions that can be supported are a point of discussion*
- For demonstration purposes, I have hardcoded `ENCAP_TYPE_ETH`, however in the future functions that are to be written, this must be taken care of.
- Overall, our library has pretty good WASM support as we had discussed earlier. As long as we follow [these guidelines](https://rustwasm.github.io/docs/book/reference/add-wasm-support-to-crate.html), we will be good.

# More areas to look into
- [Testing](https://rustwasm.github.io/wasm-bindgen/wasm-bindgen-test/index.html) the WASM binaries *There is an error when you run `cargo test --target wasm32-unknown-unknown`*
- Adding the testing into a CI pipeline *Work on this after solving the previous issue*
- Adding functions that need WASM binding generation

# Further Resources
- [Rust to WebAssembly the hard way](https://surma.dev/things/rust-to-webassembly/)
- [WABT: The WebAssembly Binary Toolkit](https://github.com/WebAssembly/wabt)
- [The `wasm-bindgen` Guide](https://rustwasm.github.io/wasm-bindgen/)
- [MDN Docs for Rust to WebAssembly](https://developer.mozilla.org/en-US/docs/WebAssembly/Rust_to_Wasm)
- [Quickstart `wasm-pack`](https://rustwasm.github.io/wasm-pack/book/quickstart.html)
- [A Disallowed MIME type error that I'd faced](https://stackoverflow.com/questions/58364162/loading-module-was-blocked-because-of-a-disallowed-mime-type-application-wasm)