### PR TITLE
Make PacketBuilder and Layer::encode_bytes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,10 @@ path = "examples/packet_as_json.rs"
 name = "pcap"
 path = "examples/pcap_example.rs"
 
+[[example]]
+name = "packet_sculpting"
+path = "examples/packet_sculpting.rs"
+
 [build-dependencies]
 syn = { version = "1.0", features = ["full"]}
 walkdir = "2"

--- a/examples/packet_sculpting.rs
+++ b/examples/packet_sculpting.rs
@@ -1,0 +1,33 @@
+use std::error::Error;
+
+use scalpel::{layers, ENCAP_TYPE_ETH};
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let _ = scalpel::register_defaults()?;
+
+    let eth_layer = Box::new(layers::ethernet::Ethernet::new());
+    let ipv4_layer = Box::new(layers::ipv4::IPv4::new());
+    let bytes = [0x12, 0x34, 0x56, 0x78, 0x90];
+
+    let builder = scalpel::builder::PacketBuilder::new()
+        .stack(eth_layer)?
+        .stack(ipv4_layer)?
+        .stack_bytes(&bytes);
+
+    let (_, result) = builder.build().unwrap();
+
+    let res_string = result[0]
+        .iter()
+        .fold(String::new(), |acc, num| {
+            acc + "0x" + &num.to_string() + " "
+        })
+        .trim_end()
+        .to_string();
+
+    println!("res: {:#?}", res_string);
+
+    let p = scalpel::Packet::from_bytes(&result[0], ENCAP_TYPE_ETH);
+    println!("{}", serde_json::to_string_pretty(&p.unwrap()).unwrap());
+
+    Ok(())
+}

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,0 +1,65 @@
+use crate::{errors::Error, Layer, Packet};
+
+#[derive(Debug, Default)]
+pub struct PacketBuilder {
+    inner: Packet,
+}
+
+impl PacketBuilder {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Stacks a layer on top of the Packet. The return value on success is the
+    /// `PacketBuilder` on success. Failure happens when a layer is attempted to
+    /// be pushed after pushing bytes. In this case it returns a
+    /// [SculptingError][`crate::errors::Error::SculptingError`].
+    pub fn stack(mut self, layer: Box<dyn Layer + Send>) -> Result<Self, Error> {
+        if self.inner.unprocessed.is_empty() {
+            self.inner.layers.push(layer);
+            Ok(self)
+        } else {
+            Err(Error::SculptingError(
+                "Cannot push layer on top of raw byte layer".to_string(),
+            ))
+        }
+    }
+
+    /// Stacks bytes on top of the packet. If the layer already contains some bytes
+    /// the new bytes are concatenated to the previous bytes in the packet.
+    pub fn stack_bytes(mut self, bytes: &[u8]) -> Self {
+        self.inner.unprocessed.extend(bytes);
+        self
+    }
+
+    pub fn build(mut self) -> Result<(Packet, Vec<Vec<u8>>), Error> {
+        let len = self.inner.layers.len();
+        if len < 1 {
+            return Err(Error::SculptingError(
+                "Packet to build does not contain any layers".to_string(),
+            ));
+        }
+        let mut results = vec![];
+
+        // last layer
+        let next_layer = if self.inner.unprocessed.is_empty() {
+            None
+        } else {
+            Some(self.inner.unprocessed.as_slice())
+        };
+        let mut bytes = self.inner.layers[len - 1].stack_and_encode(next_layer, "raw")?;
+        results.push(bytes);
+
+        for i in (0..len - 1).rev() {
+            let next_layer = results.last().map(|layer| layer.as_slice());
+            let info = self.inner.layers[i + 1].name();
+            bytes = self.inner.layers[i].stack_and_encode(next_layer, info)?;
+            results.push(bytes);
+        }
+
+        results.reverse();
+        Ok((self.inner, results))
+    }
+
+    // TODO: Add metadata related functions
+}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -15,6 +15,9 @@ pub enum Error {
 
     /// A layer registration error.
     RegisterError(String),
+
+    /// Error in sculpting
+    SculptingError(String),
 }
 
 // FIXME: Should work with `no_std`

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -30,6 +30,22 @@ pub trait Layer: Send + Debug + erased_serde::Serialize {
         bytes: &[u8],
     ) -> Result<(Option<Box<dyn Layer + Send>>, usize), Error>;
 
+    /// Main 'encoder' function.
+    ///
+    /// The return value is a `Vec<u8>` on success. This indicates the encoded packet of the
+    /// layer. Typically return a [SculptingError][`crate::errors::Error::SculptingError`],
+    /// but may as well return other values. This updates the fields of the packet using the
+    /// encoded bytes of the next layer(`next_layer`), and `info`, to provide additional details
+    /// about the packet. This can be the result of [Layer::name()][`Self::name()`]
+    /// of the next packet.
+    fn stack_and_encode(
+        &mut self,
+        _next_layer: Option<&[u8]>,
+        _info: &str,
+    ) -> Result<Vec<u8>, Error> {
+        unimplemented!()
+    }
+
     /// Name for the given layer.
     fn name(&self) -> &'static str;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,6 +60,8 @@ pub mod layer;
 
 pub mod types;
 
+pub mod builder;
+
 #[doc(inline)]
 pub use layers::register_defaults;
 

--- a/src/types/ipaddr.rs
+++ b/src/types/ipaddr.rs
@@ -13,6 +13,18 @@ use crate::errors::Error as CrateError;
 #[derive(Default, Clone, PartialEq, Eq)]
 pub struct IPv4Address([u8; 4]);
 
+impl IPv4Address {
+    /// Returns a slice containing the entire inner array.
+    pub const fn as_slice(&self) -> &[u8] {
+        &self.0
+    }
+
+    /// Returns a mutable slice containing the entire inner array.
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        &mut self.0
+    }
+}
+
 impl From<[u8; 4]> for IPv4Address {
     fn from(value: [u8; 4]) -> Self {
         Self(value)
@@ -70,6 +82,18 @@ impl Serialize for IPv4Address {
 
 #[derive(Default, Clone, PartialEq, Eq)]
 pub struct IPv6Address([u16; 8]);
+
+impl IPv6Address {
+    /// Returns a slice containing the entire inner array.
+    pub const fn as_slice(&self) -> &[u16] {
+        &self.0
+    }
+
+    /// Returns a mutable slice containing the entire inner array.
+    pub fn as_mut_slice(&mut self) -> &mut [u16] {
+        &mut self.0
+    }
+}
 
 impl From<[u16; 8]> for IPv6Address {
     fn from(value: [u16; 8]) -> Self {

--- a/src/types/macaddr.rs
+++ b/src/types/macaddr.rs
@@ -13,12 +13,30 @@ use crate::errors::Error as CrateError;
 #[derive(Default, Clone)]
 pub struct MACAddress([u8; 6]);
 
+impl MACAddress {
+    /// Returns a slice containing the entire inner array.
+    pub const fn as_slice(&self) -> &[u8] {
+        &self.0
+    }
+
+    /// Returns a mutable slice containing the entire inner array.
+    pub fn as_mut_slice(&mut self) -> &mut [u8] {
+        &mut self.0
+    }
+}
+
 impl Serialize for MACAddress {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
         serializer.serialize_str(format!("{}", self).as_str())
+    }
+}
+
+impl From<[u8; 6]> for MACAddress {
+    fn from(value: [u8; 6]) -> Self {
+        Self(value)
     }
 }
 


### PR DESCRIPTION
Refer to #56 for discussion

This aims to bring packet sculpting to scalpel. This is done by extending `Layer` with `Layer::encode_bytes()`. It's usage can be seen in `examples/packet_sculpting.rs`
```rs
let eth_layer = Box::new(layers::ethernet::Ethernet::new());
let ipv4_layer = Box::new(layers::ipv4::IPv4::new());
let bytes = [0x12, 0x34, 0x56, 0x78, 0x90];

let builder = scalpel::builder::PacketBuilder::new()
    .stack(eth_layer)?
    .stack(ipv4_layer)?
    .stack_bytes(&bytes);

let (packet, result): (scalpel::Packet, Vec<Vec<u8>>) = builder.build().unwrap();
```
`result` is a `Vec<Vec<u8>>`, where each inner `Vec<u8>` contains the bytes of that layer in the `Packet`, i.e. `result[0]` contains the Ethernet packet.

Only Ethernet and IPV4 sculpting are currently implemented.