### PR TITLE
Adding `wasm` as a feature during crate compilation

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,11 +42,11 @@ jobs:
         rustup default ${{ matrix.cfg_release_channel }}
     - name: Build with Python Bindings
       run: |
-        maturin build --verbose --all-features --release --out dist
+        maturin build --verbose --features python-bindings,logging --release --out dist
     - name: Run tests with Python Bindings
       run: |
         rustc -Vv
         cargo -V
-        cargo test --verbose --all-features
+        cargo test --verbose --features python-bindings,logging
         python -m pip install scalpel_python_bindings --find-links dist/
         python -c 'import scalpel; print(scalpel.Packet.from_bytes_py(bytes.fromhex("000573a007d168a3c4f949f686dd600000000020064020010470e5bfdead49572174e82c48872607f8b0400c0c03000000000000001af9c7001903a088300000000080022000da4700000204058c0103030801010402"), 1).as_json())'

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -50,3 +50,15 @@ jobs:
         cargo test --verbose --features python-bindings,logging
         python -m pip install scalpel_python_bindings --find-links dist/
         python -c 'import scalpel; print(scalpel.Packet.from_bytes_py(bytes.fromhex("000573a007d168a3c4f949f686dd600000000020064020010470e5bfdead49572174e82c48872607f8b0400c0c03000000000000001af9c7001903a088300000000080022000da4700000204058c0103030801010402"), 1).as_json())'
+
+    - name: Install wasm-pack
+      run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
+
+    - name: Run wasm-pack tests in firefox
+      run: wasm-pack test --firefox --headless --features wasm
+
+    - name: Run wasm-pack tests in chrome
+      run: wasm-pack test --chrome --headless --features wasm
+
+    - name: Run wasm-pack tests in node
+      run: wasm-pack test --node --features wasm

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,21 @@ hex = {version = "0.4", features = ["serde"]}
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
 erased-serde = "0.4"
-pyo3 = { version = "0.20", features = ["extension-module"], optional=true}
 log =  { version = "0.4", optional = true }
 
+[target.'cfg(target_family = "wasm")'.dependencies]
+wasm-bindgen = { version = "0.2", optional=true}
+
+
+[target.'cfg(not(target_family = "wasm"))'.dependencies]
+pyo3 = { version = "0.20", features = ["extension-module"], optional=true}
+
 [dev-dependencies]
-criterion = "0.5"
-pcap = { version = "1.3"}
 clap = { version = "4.0" , features = ["derive"] }
+
+[target.'cfg(unix)'.dev-dependencies]
+pcap = { version = "1.3"}
+criterion = "0.5"
 
 # Required by `cargo flamegraph`
 [profile.bench]
@@ -59,3 +67,5 @@ walkdir = "2"
 [features]
 python-bindings = ['pyo3']
 logging = ["log"]
+
+wasm = ['wasm-bindgen']

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,9 @@ clap = { version = "4.0" , features = ["derive"] }
 pcap = { version = "1.3"}
 criterion = "0.5"
 
+[target.'cfg(target_family = "wasm")'.dev-dependencies]
+wasm-bindgen-test = { version = "0.3"}
+
 # Required by `cargo flamegraph`
 [profile.bench]
 debug = true

--- a/examples/pcap_example.rs
+++ b/examples/pcap_example.rs
@@ -1,5 +1,4 @@
 use clap::Parser;
-use pcap::{Capture, Device, Linktype};
 
 #[derive(Parser, Debug)]
 struct Opts {
@@ -12,7 +11,10 @@ struct Opts {
     num_packets: Option<u32>,
 }
 
+#[cfg(not(feature = "wasm"))]
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    use pcap::{Capture, Device, Linktype};
+
     // Command Line Handling
     let opts = Opts::parse();
 
@@ -54,3 +56,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     Ok(())
 }
+
+#[cfg(feature = "wasm")]
+fn main() {}

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -27,7 +27,7 @@ impl core::fmt::Display for Error {
 }
 
 // Python Bindings
-#[cfg(feature = "python-bindings")]
+#[cfg(all(feature = "python-bindings", not(target_family = "wasm")))]
 impl std::convert::From<Error> for pyo3::PyErr {
     // TODO: Add proper error reporting
     fn from(_e: Error) -> pyo3::PyErr {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,3 +82,22 @@ fn scalpel(py: Python, m: &PyModule) -> PyResult<()> {
     packet::register(py, m)?;
     Ok(())
 }
+
+#[cfg(all(not(feature = "python-bindings"), target_family = "wasm"))]
+use wasm_bindgen::prelude::*;
+
+#[cfg(all(not(feature = "python-bindings"), target_family = "wasm"))]
+#[wasm_bindgen]
+pub fn dissect_packet(packet: String) -> String {
+    let _ = layers::register_defaults();
+
+    let packet = hex::decode(packet);
+
+    let packet = packet.unwrap();
+
+    let p = Packet::from_bytes(&packet, ENCAP_TYPE_ETH);
+
+    let p = p.unwrap();
+
+    serde_json::to_string_pretty(&p).unwrap()
+}

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -201,6 +201,9 @@ pub(crate) fn register(_py: Python, m: &PyModule) -> PyResult<()> {
 #[cfg(test)]
 mod tests {
 
+    #[cfg(feature = "wasm")]
+    use wasm_bindgen_test::wasm_bindgen_test;
+
     use super::*;
     use hex;
 
@@ -211,6 +214,7 @@ mod tests {
     use crate::layers::tcp::TCP_BASE_HEADER_LENGTH;
     use crate::{ENCAP_TYPE_ETH, ENCAP_TYPE_LINUX_SLL};
 
+    #[cfg_attr(feature = "wasm", wasm_bindgen_test)]
     #[test]
     fn from_bytes_fail_too_short() {
         let _ = crate::layers::register_defaults();
@@ -220,6 +224,7 @@ mod tests {
         assert!(p.is_err(), "{:?}", p.ok());
     }
 
+    #[cfg_attr(feature = "wasm", wasm_bindgen_test)]
     #[test]
     fn from_bytes_success_eth_hdr_size() {
         let _ = crate::layers::register_defaults();
@@ -229,6 +234,7 @@ mod tests {
         assert!(p.is_ok(), "{:?}", p.err());
     }
 
+    #[cfg_attr(feature = "wasm", wasm_bindgen_test)]
     #[test]
     fn parse_valid_ipv4_packet() {
         let _ = layers::register_defaults();
@@ -253,6 +259,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(feature = "wasm", wasm_bindgen_test)]
     #[test]
     fn parse_valid_ipv6_packet() {
         let _ = layers::register_defaults();
@@ -277,6 +284,7 @@ mod tests {
         );
     }
 
+    #[cfg_attr(feature = "wasm", wasm_bindgen_test)]
     #[test]
     fn parse_valid_dns_packet() {
         use crate::layers;
@@ -309,6 +317,7 @@ mod tests {
         assert!(false, "{}", register_defaults);
     }
 
+    #[cfg_attr(feature = "wasm", wasm_bindgen_test)]
     #[test]
     fn parse_failing_packet() {
         use crate::layers;
@@ -319,6 +328,7 @@ mod tests {
         assert!(should_not_fail.is_ok(), "{:?}", should_not_fail.err());
     }
 
+    #[cfg_attr(feature = "wasm", wasm_bindgen_test)]
     #[test]
     fn parse_failing_packet_2() {
         use crate::layers;
@@ -329,6 +339,7 @@ mod tests {
         assert!(should_not_fail.is_ok(), "{:?}", should_not_fail.err());
     }
 
+    #[cfg_attr(feature = "wasm", wasm_bindgen_test)]
     #[test]
     fn parse_failing_packet_3() {
         use crate::layers;

--- a/src/packet.rs
+++ b/src/packet.rs
@@ -12,7 +12,7 @@ use crate::errors::Error;
 use crate::types::{EncapType, LayerCreatorFn};
 use crate::Layer;
 
-#[cfg(feature = "python-bindings")]
+#[cfg(all(feature = "python-bindings", not(target_family = "wasm")))]
 use pyo3::prelude::*;
 
 fn get_encap_types_map() -> &'static RwLock<HashMap<EncapType, LayerCreatorFn>> {
@@ -44,7 +44,7 @@ pub(crate) fn register_defaults() -> Result<(), Error> {
 ///              Each of the following is a Layer - `Ethernet`, `IPv4`, `TCP` etc.
 ///  * `unprocessed`: The part of the original byte-stream that is not processed and captured into
 ///                   `layers` above.
-#[cfg_attr(feature = "python-bindings", pyclass)]
+#[cfg_attr(all(feature = "python-bindings", not(target_family = "wasm")), pyclass)]
 #[derive(Debug, Default, Serialize)]
 pub struct Packet {
     pub meta: PacketMetadata,
@@ -177,7 +177,7 @@ impl Packet {
 
 // Python Bindings
 #[allow(clippy::borrow_deref_ref)]
-#[cfg(feature = "python-bindings")]
+#[cfg(all(feature = "python-bindings", not(target_family = "wasm")))]
 #[pymethods]
 impl Packet {
     #[staticmethod]
@@ -192,7 +192,7 @@ impl Packet {
     }
 }
 
-#[cfg(feature = "python-bindings")]
+#[cfg(all(feature = "python-bindings", not(target_family = "wasm")))]
 pub(crate) fn register(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_class::<Packet>()?;
     Ok(())

--- a/tests/node.rs
+++ b/tests/node.rs
@@ -1,0 +1,13 @@
+//! Test suite for Node JS
+
+#![cfg(target_arch = "wasm32")]
+
+extern crate wasm_bindgen_test;
+use wasm_bindgen_test::*;
+
+#[wasm_bindgen_test]
+fn simple_dissect_test() {
+    let bytestream = "003096e6fc3900309605283888470001ddff45c0002800030000ff06a4e80a0102010a2200012af90017983210058dd58ea55010102099cd00000000";
+    scalpel::dissect_packet(bytestream.to_string());
+    assert!(true);
+}

--- a/tests/web.rs
+++ b/tests/web.rs
@@ -1,0 +1,15 @@
+//! Test suite for the Web and headless browsers.
+
+#![cfg(target_arch = "wasm32")]
+
+extern crate wasm_bindgen_test;
+use wasm_bindgen_test::*;
+
+wasm_bindgen_test_configure!(run_in_browser);
+
+#[wasm_bindgen_test]
+fn simple_dissect_test() {
+    let bytestream = "003096e6fc3900309605283888470001ddff45c0002800030000ff06a4e80a0102010a2200012af90017983210058dd58ea55010102099cd00000000";
+    scalpel::dissect_packet(bytestream.to_string());
+    assert!(true);
+}


### PR DESCRIPTION
Making several conditional compilation changes for `wasm` feature -
 - if `wasm` feature is enabled, then target must be `wasm32-unknown-unknown`
 - if `wasm` is enabled, `python-bindings` cannot be enabled.

Also made the `pyo3` dependency not applicable for `wasm` targets.