### PR TITLE
modify dissect_packet function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,10 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
 erased-serde = "0.4"
 log =  { version = "0.4", optional = true }
+console_error_panic_hook = "0.1.6"
+web-sys = "0.3.62"
+console_log = "0.2.2"
+
 
 [target.'cfg(target_family = "wasm")'.dependencies]
 wasm-bindgen = { version = "0.2", optional=true}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,17 +87,28 @@ fn scalpel(py: Python, m: &PyModule) -> PyResult<()> {
 use wasm_bindgen::prelude::*;
 
 #[cfg(all(not(feature = "python-bindings"), target_family = "wasm"))]
+#[wasm_bindgen(start)]
+pub fn initialize() {
+    console_error_panic_hook::set_once();
+}
+
+#[cfg(all(not(feature = "python-bindings"), target_family = "wasm"))]
 #[wasm_bindgen]
-pub fn dissect_packet(packet: String) -> String {
+pub fn dissect_packet( encap_type: u16 , packet: String) -> Result<String,String> {
+
     let _ = layers::register_defaults();
 
-    let packet = hex::decode(packet);
+    let packet = hex::decode(packet);   
 
     let packet = packet.unwrap();
 
-    let p = Packet::from_bytes(&packet, ENCAP_TYPE_ETH);
+    let p = Packet::from_bytes(&packet, encap_type);
 
     let p = p.unwrap();
 
-    serde_json::to_string_pretty(&p).unwrap()
+    let result = serde_json::to_string_pretty(&p).unwrap();
+
+    Ok(result)
+
 }
+

--- a/tests/node.rs
+++ b/tests/node.rs
@@ -5,9 +5,22 @@
 extern crate wasm_bindgen_test;
 use wasm_bindgen_test::*;
 
+use web_sys::console::error_1;
+use web_sys::console::log_1;
+
 #[wasm_bindgen_test]
 fn simple_dissect_test() {
     let bytestream = "003096e6fc3900309605283888470001ddff45c0002800030000ff06a4e80a0102010a2200012af90017983210058dd58ea55010102099cd00000000";
-    scalpel::dissect_packet(bytestream.to_string());
+    let encap_type = scalpel::ENCAP_TYPE_ETH;
+
+    match scalpel::dissect_packet(encap_type, bytestream.to_string()) {
+        Ok(result) => {
+            log_1(&format!("Dissected packet result: {}", result).into());
+        }
+        Err(err) => {
+            error_1(&format!("Dissect packet failed: {}", err).into());
+            panic!("Dissect packet failed: {}", err);
+        }
+    }
     assert!(true);
 }

--- a/tests/web.rs
+++ b/tests/web.rs
@@ -5,11 +5,23 @@
 extern crate wasm_bindgen_test;
 use wasm_bindgen_test::*;
 
+use web_sys::console::error_1;
+use web_sys::console::log_1;
 wasm_bindgen_test_configure!(run_in_browser);
 
 #[wasm_bindgen_test]
 fn simple_dissect_test() {
     let bytestream = "003096e6fc3900309605283888470001ddff45c0002800030000ff06a4e80a0102010a2200012af90017983210058dd58ea55010102099cd00000000";
-    scalpel::dissect_packet(bytestream.to_string());
+    let encap_type = scalpel::ENCAP_TYPE_ETH;
+
+    match scalpel::dissect_packet(encap_type, bytestream.to_string()) {
+        Ok(result) => {
+            log_1(&format!("Dissected packet result: {}", result).into());
+        }
+        Err(err) => {
+            error_1(&format!("Dissect packet failed: {}", err).into());
+            panic!("Dissect packet failed: {}", err);
+        }
+    }
     assert!(true);
 }


### PR DESCRIPTION
This PR adds following features 
1. The API should return a Result and accept encap_type. ( Returning Result. We'll need to explore a bit how the Result can be returned in the wasm module and how the caller would use it)
2. We should also have the console_error_panic_handler enabled if wasm is being compiled. So that panics can be logged using console.error
as mentioned in #66 under https://github.com/ystero-dev/scalpel/pull/66#issuecomment-2036258467